### PR TITLE
Ensure latest packages are not deleted

### DIFF
--- a/action.php
+++ b/action.php
@@ -149,6 +149,11 @@ foreach ($packageNodes as $packageNode) {
             // Packages. Keep this safeguard until the bug has been resolved.
             continue;
         }
+        
+        if ('latest' == $packageVersion) {
+            // Do not delete packages tagged as 'latest"
+            continue;
+        }    
 
         if (!$removeSemver && isSemanticVersion($packageVersion)) {
             debug(sprintf('[%s] [%s] Semantic versions will not be removed unless remove-semver is set to true', $repoNameWithOwner, $packageNameWithVersion));


### PR DESCRIPTION
If a single repository has multiple packages the "latest" packages of packages with an altering name, compared to the repo name, get deleted.